### PR TITLE
Rejigger things such that the timeout tests pass

### DIFF
--- a/t/AnyEvent-Yubico.t
+++ b/t/AnyEvent-Yubico.t
@@ -8,7 +8,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 5;
+use Test::More tests => 6;
 use Test::Exception;
 BEGIN { use_ok('AnyEvent::Yubico') };
 
@@ -39,18 +39,19 @@ $validator->{urls} = [ "http://127.0.0.1:0" ];
 
 is($validator->verify_async("vvgnkjjhndihvgdftlubvujrhtjnllfjneneugijhfll")->recv()->{status}, "Connection refused", "invalid URL");
 
+$validator->{local_timeout} = 0.0001;
+
+is($validator->verify_sync("vvgnkjjhndihvgdftlubvujrhtjnllfjneneugijhfll")->{status}, "Connection timed out", "timeout");
+
 $validator->{urls} = $default_urls;
+$validator->{local_timeout} = 30.0;
 
 subtest 'Tests that require access to the Internet' => sub {
 	if(exists($ENV{'NO_INTERNET'})) {
 		plan skip_all => 'Internet tests';
 	} else {
-		plan tests => 6;
+		plan tests => 5;
 	}
-
-	$validator->{local_timeout} = 0.01;
-	is($validator->verify_sync("vvgnkjjhndihvgdftlubvujrhtjnllfjneneugijhfll")->{status}, "Connection timed out", "timeout");
-	$validator->{local_timeout} = 30.0;
 
 	is($validator->verify_sync("ccccccbhjkbulvkhvfuhlltctnjtgrvjuvcllliufiht")->{status}, "REPLAYED_OTP", "replayed OTP");
 


### PR DESCRIPTION
Computers are fast.  Put a couple extra zeros in the timeout value appears to be necessary.

Also...  keep on using the dummy (http://127.0.0.1:0) through the timeout test; this allows the test to pass.  Why, I have no idea, but it won't pass for me otherwise.

Thanks :)