### PR TITLE
Updates to work better with new YubiCloud

### DIFF
--- a/lib/AnyEvent/Yubico.pm
+++ b/lib/AnyEvent/Yubico.pm
@@ -102,12 +102,12 @@ sub verify_async {
 			}
 			if ($hdr->{Status} eq '400' or
 			    $hdr->{Status} =~ /^5/) {
+				$retries++;
 				if ($retries > $self->{max_retries}) {
 					$inner_var->send({status => $hdr->{Reason}});
 					return;
 				}
 
-				$retries++;
 				push(@requests, http_get("$url$query",
 						timeout => $self->{local_timeout},
 						tls_ctx => 'high',

--- a/t/AnyEvent-Yubico.t
+++ b/t/AnyEvent-Yubico.t
@@ -34,8 +34,8 @@ ok(defined($validator) && ref $validator eq "AnyEvent::Yubico", "new() works");
 
 is($validator->sign($test_params), $test_signature, "sign() works");
 
-my $default_urls = $validator->{urls};
-$validator->{urls} = [ "http://127.0.0.1:0" ];
+my $default_url = $validator->{url};
+$validator->{url} = "http://127.0.0.1:0";
 
 is($validator->verify_async("vvgnkjjhndihvgdftlubvujrhtjnllfjneneugijhfll")->recv()->{status}, "Connection refused", "invalid URL");
 
@@ -43,7 +43,7 @@ $validator->{local_timeout} = 0.0001;
 
 is($validator->verify_sync("vvgnkjjhndihvgdftlubvujrhtjnllfjneneugijhfll")->{status}, "Connection timed out", "timeout");
 
-$validator->{urls} = $default_urls;
+$validator->{url} = $default_url;
 $validator->{local_timeout} = 30.0;
 
 subtest 'Tests that require access to the Internet' => sub {

--- a/t/AnyEvent-Yubico.t
+++ b/t/AnyEvent-Yubico.t
@@ -8,8 +8,9 @@
 use strict;
 use warnings;
 
-use Test::More tests => 6;
+use Test::More tests => 7;
 use Test::Exception;
+require Test::MockModule;
 BEGIN { use_ok('AnyEvent::Yubico') };
 
 #########################
@@ -71,4 +72,56 @@ subtest 'Tests that require access to the Internet' => sub {
 	is($validator->sign($result), $sig, "signature is correct");
 
 	ok(! $validator->verify("ccccccbhjkbubrbnrtifbiuhevinenrhtlckuctjjuuu"), "verify(\$bad_otp)");
+};
+
+subtest 'HTTP error tests' => sub {
+    plan tests => 4;
+
+    my @mocked_responses = ();
+    # AnyEvent::Yubico `use`es AnyEvent::HTTP to get http_get
+    my $mock_anyevent_http = Test::MockModule->new('AnyEvent::Yubico');
+    $mock_anyevent_http->redefine('http_get', sub {
+        my $callback = pop;
+        my $response = pop @mocked_responses;
+        $callback->($response->{body}, $response->{head});
+    });
+
+    my $error_response = { body => "Nope.", head => { Status => 500, Reason => 'Internal Server Error' } };
+    my $ratelimit_response = { body => "Nope.", head => { Status => 429 } };
+    my $almostok_response = { body => "status=OK", head => { Status => 200 } };
+
+    push @mocked_responses, $ratelimit_response;
+
+    my $result = $validator->verify_sync("ccccccbhjkbubrbnrtifbiuhevinenrhtlckuctjjuuu");
+    is($result->{status}, "RATE_LIMITED", "detect rate limiting");
+
+    push @mocked_responses, $ratelimit_response;
+    push @mocked_responses, $almostok_response;
+    push @mocked_responses, $error_response;
+    push @mocked_responses, $error_response;
+
+    # Disable checking signature because I CBF calculating it for the test
+    $validator->{api_key} = '';
+
+    # This throws a response nonce mismatch, which is correct because
+    # the mocked response has no nonce. It's too annoying to grab that
+    # nonce in the mock, and it's good to validate that we do error
+    # when the nonce doesn't match anyway.
+    throws_ok { $validator->verify_sync("ccccccbhjkbubrbnrtifbiuhevinenrhtlckuctjjuuu"); } qr/Response nonce does not match/, "Retry works, as does nonce checking";
+
+    # Just to make sure that the 500s are being retried rather than us
+    # mocking the responses in the wrong order
+    $result = $validator->verify_sync("ccccccbhjkbubrbnrtifbiuhevinenrhtlckuctjjuuu");
+    is($result->{status}, "RATE_LIMITED", "double check the retrying mock works");
+
+
+    # 3 retries means give up after 4th error
+    push @mocked_responses, $almostok_response;
+    push @mocked_responses, $error_response;
+    push @mocked_responses, $error_response;
+    push @mocked_responses, $error_response;
+    push @mocked_responses, $error_response;
+
+    $result = $validator->verify_sync("ccccccbhjkbubrbnrtifbiuhevinenrhtlckuctjjuuu");
+    is($result->{status}, "Internal Server Error", "Retries are limited");
 };

--- a/t/AnyEvent-Yubico.t
+++ b/t/AnyEvent-Yubico.t
@@ -8,7 +8,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 11;
+use Test::More tests => 7;
 use Test::Exception;
 require Test::MockModule;
 BEGIN { use_ok('AnyEvent::Yubico') };
@@ -37,15 +37,7 @@ is($validator->sign($test_params), $test_signature, "sign() works");
 
 my $default_urls = $validator->{urls};
 
-$validator->{urls} = ["url_one", "url_two"];
-
-is($validator->next_url(), "url_one", "next url cycles");
-is($validator->next_url(), "url_two", "next url cycles");
-is($validator->next_url(), "url_one", "next url cycles");
-
 $validator->{urls} = ["http://127.0.0.1:0"];
-
-is($validator->next_url(), "http://127.0.0.1:0", "next_url works after changin urls");
 
 is($validator->verify_async("vvgnkjjhndihvgdftlubvujrhtjnllfjneneugijhfll")->recv()->{status}, "Connection refused", "invalid URL");
 
@@ -67,6 +59,11 @@ subtest 'Tests that require access to the Internet' => sub {
 
 	$validator = AnyEvent::Yubico->new({
 		client_id => $client_id,
+                urls => [ "https://api.yubico.com/wsapi/2.0/verify",
+                          "https://api.yubico.com/wsapi/2.0/verify",
+                          "https://api.yubico.com/wsapi/2.0/verify",
+                          "https://api.yubico.com/wsapi/2.0/verify",
+                          "https://api.yubico.com/wsapi/2.0/verify" ]
 	});
 
 	my $result = $validator->verify_sync("ccccccbhjkbubrbnrtifbiuhevinenrhtlckuctjjuuu");


### PR DESCRIPTION
The updated YubiCloud now does its own high availability and does not require parallel querying of several servers.

* Updates the defaults to just use api.yubico.com
* Adds retry logic, since we're not defaulting to 5 tries in parallel any more.